### PR TITLE
Use force sensor to detect grasp and fix

### DIFF
--- a/pick_place_trees/behavior_tree.py
+++ b/pick_place_trees/behavior_tree.py
@@ -45,7 +45,7 @@ def create_pickup_tree(manipulator, object_detector, force_sensor,
    
     calculate_place_position = CalculateManipulatorPosition(name="Calculate place position", manipulator=manipulator, object_position=object_target_position)
     move_to_place = Retry(name="Retry move to place", child=MoveToPosition(name="Move to place", manipulator=manipulator, key_target_pose=calculate_place_position.key_manipulator_target_position), num_failures=10)
-    release_object = ReleaseObject(name="Release object", manipulator=manipulator, force_sensor=force_sensor)
+    release_object = Retry(name="Retry release object", child=ReleaseObject(name="Release object", manipulator=manipulator, force_sensor=force_sensor), num_failures=10)
     move_home = Retry(name="Retry move to home", child=MoveToPosition(name="Move home", manipulator=manipulator, target_position=manipulator_end_position), num_failures=10)
 
     pick_sequence = py_trees.composites.Sequence(name="Pick sequence", memory=False, children=[

--- a/pick_place_trees/behavior_tree.py
+++ b/pick_place_trees/behavior_tree.py
@@ -37,15 +37,20 @@ def create_pickup_tree(manipulator, object_detector, force_sensor,
     
     detect_object = DetectObject(name="Detect object", object_detector=object_detector)
     calculate_pick_position = CalculateManipulatorPosition(name="Calculate pick position", manipulator=manipulator, key_object_position=detect_object.key_object_pose)
-    move_to_object = MoveToPosition(name="Move to object", manipulator=manipulator, key_target_pose=calculate_pick_position.key_manipulator_target_position)
+    move_to_pregrasp = MoveToPosition(name="Move to pregrasp", manipulator=manipulator, key_target_pose=calculate_pick_position.key_manipulator_target_position)
     grasp_object = GraspObject(name="Grasp object", manipulator=manipulator, force_sensor=force_sensor)
    
     calculate_place_position = CalculateManipulatorPosition(name="Calculate place position", manipulator=manipulator, object_position=object_target_position)
     move_to_place = MoveToPosition(name="Move to place", manipulator=manipulator, key_target_pose=calculate_place_position.key_manipulator_target_position)
-    release_object = ReleaseObject(name="Release object", manipulator=manipulator)
+    release_object = ReleaseObject(name="Release object", manipulator=manipulator, force_sensor=force_sensor)
     move_home = MoveToPosition(name="Move home", manipulator=manipulator, target_position=manipulator_end_position)
 
-    pick_sequence = py_trees.composites.Sequence(name="Pick sequence", memory=False, children=[detect_object, calculate_pick_position, move_to_object, grasp_object])
+    pick_sequence = py_trees.composites.Sequence(name="Pick sequence", memory=False, children=[
+        detect_object,
+        calculate_pick_position,
+        move_to_pregrasp,
+        grasp_object
+    ])
     place_sequence = py_trees.composites.Sequence(name="Place sequence", memory=False, children=[calculate_place_position, move_to_place, release_object, move_home])
 
     root = py_trees.composites.Sequence(name="Pick and place", memory=False)
@@ -69,7 +74,7 @@ def run_tree(root, world_state, max_num_runs=1):
     root.setup_with_descendants()
     while True:
         try:
-            print("\n-------- Tick ------------ \n")
+            print(f"\n-------- Tick {max_num_runs}------------ \n")
             root.tick_once()
             print("\n")
             print(py_trees.display.unicode_tree(root, show_status=True))
@@ -77,6 +82,7 @@ def run_tree(root, world_state, max_num_runs=1):
                 print("Task completed successfully!")
                 break
             time.sleep(1)
+            max_num_runs -= 1
         except KeyboardInterrupt:
             break
 

--- a/pick_place_trees/behavior_tree.py
+++ b/pick_place_trees/behavior_tree.py
@@ -82,7 +82,6 @@ def run_tree(root, world_state, max_num_runs=1):
         try:
             print(f"\n-------- Tick {max_num_runs}------------ \n")
             root.tick_once()
-            print("\n")
             print(py_trees.display.unicode_tree(root, show_status=True))
             if root.status == py_trees.common.Status.SUCCESS:
                 print("Task completed successfully!")
@@ -90,6 +89,7 @@ def run_tree(root, world_state, max_num_runs=1):
             time.sleep(1)
             max_num_runs -= 1
         except KeyboardInterrupt:
+            root.interrupt()
             break
 
 

--- a/pick_place_trees/behavior_tree.py
+++ b/pick_place_trees/behavior_tree.py
@@ -44,7 +44,7 @@ def create_pickup_tree(manipulator, object_detector, force_sensor,
 
     grasp_object = GraspObject(name="Grasp object", manipulator=manipulator, force_sensor=force_sensor)
     recovery_failed_grasp = SuccessIsFailure(name="Recovery is error for sequence", child=Retry(name="Retry recovery grasp", child=ReleaseObject(name="Recovery grasp", manipulator=manipulator, force_sensor=force_sensor), num_failures=10))
-    grasp_and_recovery = Retry(name="Rety Grasp", child=py_trees.composites.Selector(name="Grasp and recovery", memory=False, children=[grasp_object, recovery_failed_grasp]), num_failures=10)
+    grasp_and_recovery = py_trees.composites.Selector(name="Grasp and recovery", memory=False, children=[grasp_object, recovery_failed_grasp])
    
     calculate_place_position = CalculateManipulatorPosition(name="Calculate place position", manipulator=manipulator, object_position=object_target_position)
     move_to_place = MoveToPosition(name="Move to place", manipulator=manipulator, key_target_pose=calculate_place_position.key_manipulator_target_position)

--- a/pick_place_trees/mock_manipulator.py
+++ b/pick_place_trees/mock_manipulator.py
@@ -53,8 +53,9 @@ class MockManipulatorState:
         grasp_position = self.get_grasp_position_for(object_position)
         if self.endeffector_position is None:
             return False
+
         distance = math.dist(self.endeffector_position, grasp_position)
-        return distance <= self._grasp_tolerance
+        return distance < self._grasp_tolerance
 
 
 class MockManipulator:

--- a/pick_place_trees/task_grasp_object.py
+++ b/pick_place_trees/task_grasp_object.py
@@ -48,3 +48,22 @@ class GraspObject(py_trees.behaviour.Behaviour):
         #    self.logger.info("Open gripper.")
 
         return py_trees.common.Status.FAILURE
+
+
+class IsGrasped(py_trees.behaviour.Behaviour):
+    def __init__(self, name="Is Grasped", force_sensor: MockForceFeedbackSensor = None):
+        super(IsGrasped, self).__init__(name=name)
+        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
+
+        self.force_sensor = force_sensor
+
+    def update(self) -> py_trees.common.Status:
+        """
+        Checks if an object is grasped by the manipulator.
+        """
+        if self.force_sensor.detect_force():
+            self.logger.info("Object is grasped.")
+            return py_trees.common.Status.SUCCESS
+
+        self.logger.info("Object is not grasped.")
+        return py_trees.common.Status.FAILURE

--- a/pick_place_trees/task_grasp_object.py
+++ b/pick_place_trees/task_grasp_object.py
@@ -3,9 +3,9 @@ import py_trees
 from pick_place_trees.mock_force_feedback_sensor import MockForceFeedbackSensor
 from pick_place_trees.mock_manipulator import MockManipulator
 
-class ReleaseObject(py_trees.behaviour.Behaviour):
-    def __init__(self, name="Release Object", manipulator: MockManipulator = None, force_sensor: MockForceFeedbackSensor = None):
-        super(ReleaseObject, self).__init__(name=name)
+class GripperOpen(py_trees.behaviour.Behaviour):
+    def __init__(self, name="Gripper open", manipulator: MockManipulator = None, force_sensor: MockForceFeedbackSensor = None):
+        super(GripperOpen, self).__init__(name=name)
         self.logger.debug("%s.__init__()" % (self.__class__.__name__))
 
         self.manipulator = manipulator
@@ -24,9 +24,9 @@ class ReleaseObject(py_trees.behaviour.Behaviour):
         return py_trees.common.Status.FAILURE
 
 
-class GraspObject(py_trees.behaviour.Behaviour):
-    def __init__(self, name="Grasp Object", manipulator: MockManipulator = None, force_sensor: MockForceFeedbackSensor = None):
-        super(GraspObject, self).__init__(name=name)
+class GripperClose(py_trees.behaviour.Behaviour):
+    def __init__(self, name="Gripper close", manipulator: MockManipulator = None, force_sensor: MockForceFeedbackSensor = None):
+        super(GripperClose, self).__init__(name=name)
         self.logger.debug("%s.__init__()" % (self.__class__.__name__))
 
         self.manipulator = manipulator
@@ -44,15 +44,12 @@ class GraspObject(py_trees.behaviour.Behaviour):
                 return py_trees.common.Status.SUCCESS
             
         self.logger.info("Failed to grasp object.")
-        #if self.manipulator.release():
-        #    self.logger.info("Open gripper.")
-
         return py_trees.common.Status.FAILURE
 
 
-class IsGrasped(py_trees.behaviour.Behaviour):
-    def __init__(self, name="Is Grasped", force_sensor: MockForceFeedbackSensor = None):
-        super(IsGrasped, self).__init__(name=name)
+class GripperIsClosed(py_trees.behaviour.Behaviour):
+    def __init__(self, name="Gripper is closed", force_sensor: MockForceFeedbackSensor = None):
+        super(GripperIsClosed, self).__init__(name=name)
         self.logger.debug("%s.__init__()" % (self.__class__.__name__))
 
         self.force_sensor = force_sensor

--- a/pick_place_trees/task_grasp_object.py
+++ b/pick_place_trees/task_grasp_object.py
@@ -38,10 +38,6 @@ class GraspObject(py_trees.behaviour.Behaviour):
         Grasps an object in the environment.
         """
 
-        if self.manipulator.gripper_closed:
-            self.logger.info("Gripper is already closed.")
-            self.manipulator.release()
-
         if self.manipulator.grasp():
             self.logger.info("Attempting to grasp object.")
             if self.force_sensor.detect_force():
@@ -49,4 +45,7 @@ class GraspObject(py_trees.behaviour.Behaviour):
                 return py_trees.common.Status.SUCCESS
             
         self.logger.info("Failed to grasp object.")
+        if self.manipulator.release():
+            self.logger.info("Open gripper.")
+
         return py_trees.common.Status.FAILURE

--- a/pick_place_trees/task_grasp_object.py
+++ b/pick_place_trees/task_grasp_object.py
@@ -1,46 +1,52 @@
 import py_trees
 
+from pick_place_trees.mock_force_feedback_sensor import MockForceFeedbackSensor
+from pick_place_trees.mock_manipulator import MockManipulator
+
 class ReleaseObject(py_trees.behaviour.Behaviour):
-    def __init__(self, name="Release Object", manipulator=None):
+    def __init__(self, name="Release Object", manipulator: MockManipulator = None, force_sensor: MockForceFeedbackSensor = None):
         super(ReleaseObject, self).__init__(name=name)
         self.logger.debug("%s.__init__()" % (self.__class__.__name__))
 
         self.manipulator = manipulator
-        self._object_released = False
+        self.force_sensor = force_sensor
 
     def update(self) -> py_trees.common.Status:
         """
         Releases an object in the environment.
         """
         if self.manipulator.release():
-            self._object_released = True
-            self.logger.debug("Object released.")
-            return py_trees.common.Status.SUCCESS
-        else:
-            self._object_released = False
-            self.logger.debug("Failed to release object.")
-
+            if not self.force_sensor.detect_force():
+                self.logger.debug("Object released.")
+                return py_trees.common.Status.SUCCESS
+        
+        self._object_released = False
+        self.logger.debug("Failed to release object.")
         return py_trees.common.Status.FAILURE
 
+
 class GraspObject(py_trees.behaviour.Behaviour):
-    def __init__(self, name="Grasp Object", manipulator=None, force_sensor=None):
+    def __init__(self, name="Grasp Object", manipulator: MockManipulator = None, force_sensor: MockForceFeedbackSensor = None):
         super(GraspObject, self).__init__(name=name)
         self.logger.debug("%s.__init__()" % (self.__class__.__name__))
 
         self.manipulator = manipulator
         self.force_sensor = force_sensor
-        self._object_grasped = False
 
     def update(self) -> py_trees.common.Status:
         """
         Grasps an object in the environment.
         """
-        if self.manipulator.grasp():
-            self._object_grasped = True
-            self.logger.debug("Object grasped.")
-            return py_trees.common.Status.SUCCESS
-        else:
-            self._object_grasped = False
-            self.logger.debug("Failed to grasp object.")
 
+        if self.manipulator.gripper_closed:
+            self.logger.info("Gripper is already closed.")
+            self.manipulator.release()
+
+        if self.manipulator.grasp():
+            self.logger.info("Attempting to grasp object.")
+            if self.force_sensor.detect_force():
+                self.logger.info("Object grasped successfully.")
+                return py_trees.common.Status.SUCCESS
+            
+        self.logger.info("Failed to grasp object.")
         return py_trees.common.Status.FAILURE

--- a/pick_place_trees/task_grasp_object.py
+++ b/pick_place_trees/task_grasp_object.py
@@ -17,11 +17,10 @@ class ReleaseObject(py_trees.behaviour.Behaviour):
         """
         if self.manipulator.release():
             if not self.force_sensor.detect_force():
-                self.logger.debug("Object released.")
+                self.logger.info("Object released.")
                 return py_trees.common.Status.SUCCESS
         
-        self._object_released = False
-        self.logger.debug("Failed to release object.")
+        self.logger.info("Failed to release object.")
         return py_trees.common.Status.FAILURE
 
 
@@ -45,7 +44,7 @@ class GraspObject(py_trees.behaviour.Behaviour):
                 return py_trees.common.Status.SUCCESS
             
         self.logger.info("Failed to grasp object.")
-        if self.manipulator.release():
-            self.logger.info("Open gripper.")
+        #if self.manipulator.release():
+        #    self.logger.info("Open gripper.")
 
         return py_trees.common.Status.FAILURE

--- a/pick_place_trees/task_move_to_position.py
+++ b/pick_place_trees/task_move_to_position.py
@@ -1,7 +1,9 @@
 import py_trees
 
+from pick_place_trees.mock_manipulator import MockManipulator
+
 class CalculateManipulatorPosition(py_trees.behaviour.Behaviour):
-    def __init__(self, name="Calculate Pick Position", manipulator = None, key_object_position: str = "", object_position: tuple[float, float, float] = None):
+    def __init__(self, name="Calculate Pick Position", manipulator: MockManipulator = None, key_object_position: str = "", object_position: tuple[float, float, float] = None):
         super(CalculateManipulatorPosition, self).__init__(name=name)
         self.logger.debug("%s.__init__()" % (self.__class__.__name__))
 
@@ -34,7 +36,7 @@ class CalculateManipulatorPosition(py_trees.behaviour.Behaviour):
 
 
 class MoveToPosition(py_trees.behaviour.Behaviour):
-    def __init__(self, name="Move to Position", manipulator=None, key_target_pose: str = "", target_position: tuple[float, float, float] = None):
+    def __init__(self, name="Move to Position", manipulator: MockManipulator = None, key_target_pose: str = "", target_position: tuple[float, float, float] = None):
         super(MoveToPosition, self).__init__(name=name)
         
         self.logger.debug("%s.__init__()" % (self.__class__.__name__))

--- a/pick_place_trees/world_state.py
+++ b/pick_place_trees/world_state.py
@@ -128,6 +128,11 @@ class WorldState:
                 )
                 self._holding_object = True
 
+        if not is_gripped:
+            # Gripper is open, reset slip simulation
+            self._simulate_object_slip = False
+            print("Reset slip simulation (gripper open)")
+
     def is_object_within_grasp_offset(self) -> bool:
         """
         Checks if the object is within grasp offset by calling the manipulator's function.

--- a/tests/test_world_state.py
+++ b/tests/test_world_state.py
@@ -69,6 +69,7 @@ class TestWorldState(unittest.TestCase):
         self.manipulator_state.gripper_closed = True 
         self.world_state.update_holding_object()
         self.assertTrue(self.world_state.holding_object)
+        self.assertFalse(self.world_state._simulate_object_slip)
 
     def test_holding_object_pose_update(self):
         """Test that after holding the object and moving the end effector, the position is updated correctly."""

--- a/tests/test_world_state.py
+++ b/tests/test_world_state.py
@@ -68,7 +68,7 @@ class TestWorldState(unittest.TestCase):
         self.assertFalse(self.world_state.holding_object)
         self.manipulator_state.gripper_closed = True 
         self.world_state.update_holding_object()
-        self.assertFalse(self.world_state.holding_object)
+        self.assertTrue(self.world_state.holding_object)
 
     def test_holding_object_pose_update(self):
         """Test that after holding the object and moving the end effector, the position is updated correctly."""


### PR DESCRIPTION
Use a force sensor to detect grasp.

There appear to be bugs in the mock objects.
A unit test designed to verify a successful grasp was incorrectly testing for an unsuccessful grasp.
The update_holding_object function only reset the _simulate_object_slip flag in scenarios following a successful grasp (when the object is marked as held, but the gripper is open).
As I am uncertain about the original rationale for using a flag instead of the gripper's status directly, I resolved the issue by resetting the flag whenever the gripper is open.